### PR TITLE
Software Attribution 

### DIFF
--- a/report/red_wine_quality_prediction.ipynb
+++ b/report/red_wine_quality_prediction.ipynb
@@ -303,13 +303,13 @@
     "- `citric acid`: grams of citric acid per cubic decimeter.\n",
     "- `residual sugar`: grams of residual sugar per cubic decimeter.\n",
     "- `chlorides`: grams of sodium chloride per cubic decimeter.\n",
-    "- `free sulfur dioxide`: grams of unreacted sulfur dioxide per cubic decimeter.\n",
-    "- `total sulfur dioxide`: grams of total sulfur dioxide per cubic decimeter.\n",
+    "- `free sulfur dioxide`: grams of unreacted sulfur dioxide per cubic decimeter. \n",
+    "- `total sulfur dioxide`: grams of total sulfur dioxide per cubic decimeter {cite}`wineask`. \n",
     "- `density`: density of the wine in grams per cubic decimeter.\n",
     "- `pH`: pH value of the wine\n",
-    "- `sulphates`: gra\n",
-    "- `alcohol`\n",
-    "- `quality`"
+    "- `sulphates`: grams of potassium sulphate per cubic decimeter\n",
+    "- `alcohol` : percentage volume of alcohol content. \n",
+    "- `quality` : integer range from 0 (representing low-quality) to 10 (representing high-quality)."
    ]
   },
   {

--- a/report/red_wine_quality_prediction.ipynb
+++ b/report/red_wine_quality_prediction.ipynb
@@ -247,9 +247,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Red wines have a long history that can be traced all the way back to the ancient Greeks. Today, they are more accessible to an average person than ever and the entire industry is estimated to be worth around 109.5 billion USD (The Business Research Company). Despite its ubiquity, most people can barely tell the difference between a good and a bad wine, to the point where we need trained professionals (sommeliers) to understand the difference. In this project, we seek to use machine learning algorithms to predict the quality of the wine based on the physiochemical properties of the liquid.  This model, if effective, could allow manufactures and suppliers to have a more robust understanding of the wine quality based on measurable properties.\n",
-    "\n",
-    "To complete this analysis, visualize data, and build the machine learning model, Python {cite}`10.5555/1593511` and associated libraries, including Pandas {cite}`mckinney2010data`, NumPy {cite}`numpy`, scikit-learn {cite}`scikit-learn`, Altair {cite}`vanderplas2018altair`, Seaborn {cite}`Waskom2021`, and Matplotlib {cite}`Hunter:2007` were used. "
+    "Red wines have a long history that can be traced all the way back to the ancient Greeks. Today, they are more accessible to an average person than ever and the entire industry is estimated to be worth around 109.5 billion USD (The Business Research Company). Despite its ubiquity, most people can barely tell the difference between a good and a bad wine, to the point where we need trained professionals (sommeliers) to understand the difference. In this project, we seek to use machine learning algorithms to predict the quality of the wine based on the physiochemical properties of the liquid.  This model, if effective, could allow manufactures and suppliers to have a more robust understanding of the wine quality based on measurable properties."
    ]
   },
   {
@@ -489,6 +487,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Software Attributions"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To complete this analysis, visualize data, and build the machine learning model, Python {cite}`10.5555/1593511` and associated libraries, including Pandas {cite}`mckinney2010data`, NumPy {cite}`numpy`, scikit-learn {cite}`scikit-learn`, Altair {cite}`vanderplas2018altair`, Seaborn {cite}`Waskom2021`, and Matplotlib {cite}`Hunter:2007` were used. \n",
+    "\n",
+    "We acknowledge the contributions of the open-source community and developers behind these tools, which significantly facilitated our analysis."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## References "
    ]
   },
@@ -508,9 +522,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "conda-env-red_wine_quality_prediction-py",
+   "display_name": "dsci522_group20_env",
    "language": "python",
-   "name": "conda-env-red_wine_quality_prediction-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/report/references.bib
+++ b/report/references.bib
@@ -119,3 +119,10 @@
   doi       = {10.1109/MCSE.2007.55},
   year      = 2007
 }
+
+@article{wineask,
+  title={Understanding Molecular SO2},
+  author = {AWRI},
+  year = {2017}, 
+  url = {https://www.awri.com.au/wp-content/uploads/2018/03/s1886.pdf}
+}


### PR DESCRIPTION
Software attribution is added to the end of the report, before references, instead of in the introduction. Note: I haven't built the jb with this yet. 